### PR TITLE
Use 64-bit addition in Miden example

### DIFF
--- a/miden_stark/src/fib.rs
+++ b/miden_stark/src/fib.rs
@@ -21,6 +21,7 @@ pub fn fib(n: u32) -> (impl Fn() -> (StackOutputs, ExecutionProof), (VmStateIter
                 movup.4
                 u32overflowing_add3
                 drop
+                swap
             end
         end
     "#

--- a/miden_stark/src/fib.rs
+++ b/miden_stark/src/fib.rs
@@ -10,9 +10,17 @@ pub fn fib(n: u32) -> (impl Fn() -> (StackOutputs, ExecutionProof), (VmStateIter
         r#"
         begin
             push.0
+            push.0
+            push.0
             push.1
             repeat.{n}
-                swap dup.1 add
+                dup
+                movup.3
+                u32overflowing_add
+                dup.3
+                movup.4
+                u32overflowing_add3
+                drop
             end
         end
     "#


### PR DESCRIPTION
For consistency, Miden VM would, similar to RISC-Zero VM, use 64-bit integers.

To do so, we rephrase the overflowing addition code from https://github.com/0xPolygonMiden/miden-vm/blob/main/stdlib/asm/math/u64.masm#L14. 

The idea is that, we push four elements: 0, 0, 0, 1, representing a_h, a_l, b_h, b_l. Then, we perform over the stack to do the Fibonacci operation. This would make Miden slower, but it is the expected behavior.